### PR TITLE
fix & improve validIdentifier rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.gradle/
+/build/

--- a/src/com/ansorgit/plugins/bash/lang/psi/util/BashIdentifierUtil.java
+++ b/src/com/ansorgit/plugins/bash/lang/psi/util/BashIdentifierUtil.java
@@ -15,37 +15,24 @@
 
 package com.ansorgit.plugins.bash.lang.psi.util;
 
+import java.util.regex.Pattern;
+
 /**
  * @author jansorg
  */
 public final class BashIdentifierUtil {
+
+    private static final Pattern newVariablePattern = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+    private static final Pattern anyIdentifier = Pattern.compile("|@|$|#|?|!|*|-|[0-9]|[a-zA-Z_][a-zA-Z0-9_]");
+
     private BashIdentifierUtil() {
     }
 
     public static boolean isValidNewVariableName(String text) {
-        return isValidIdentifier(text); //fixme should be enhanced (no time atm)
+        return text != null && newVariablePattern.matcher(text).matches();
     }
 
     public static boolean isValidIdentifier(CharSequence text) {
-        if (text == null || text.length() == 0) {
-            return false;
-        }
-
-        char first = text.charAt(0);
-
-        if (first >= '0' && first <= '9') {
-            //builtin $1 to $9 are valid, all other variables which start with a digit are not
-            return text.length() == 1;
-        }
-
-        for (int i = 0; i < text.length(); i++) {
-            char c = text.charAt(i);
-
-            if ((c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '@' && c != '$' && c != '#' && c != '?' && c != '!' && c != '*' && c != '-') {
-                return false;
-            }
-        }
-
-        return true;
+        return text != null && anyIdentifier.matcher(text).matches();
     }
 }

--- a/test/com/ansorgit/plugins/bash/lang/psi/util/BashIdentifierUtilTest.java
+++ b/test/com/ansorgit/plugins/bash/lang/psi/util/BashIdentifierUtilTest.java
@@ -41,6 +41,8 @@ public class BashIdentifierUtilTest {
         Assert.assertTrue(BashIdentifierUtil.isValidIdentifier("-"));
         Assert.assertTrue(BashIdentifierUtil.isValidIdentifier("_"));
 
+        Assert.assertTrue(BashIdentifierUtil.isValidIdentifier(""));
+
         Assert.assertTrue(BashIdentifierUtil.isValidIdentifier("0"));
         Assert.assertTrue(BashIdentifierUtil.isValidIdentifier("1"));
         Assert.assertTrue(BashIdentifierUtil.isValidIdentifier("2"));
@@ -54,9 +56,25 @@ public class BashIdentifierUtilTest {
 
         Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("123"));
         Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("1a"));
+        Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("a$a"));
+        Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("a-a"));
+        Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("@a"));
 
         Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("α"));
         Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("α1"));
         Assert.assertFalse(BashIdentifierUtil.isValidIdentifier("разработка"));
     }
+
+    @Test
+    public void testValidNewVariableName() throws Exception {
+        Assert.assertTrue(BashIdentifierUtil.isValidNewVariableName("abcde_xyz0123456789"));
+
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName(""));
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName("0"));
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName("0a"));
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName("$"));
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName("a$a"));
+        Assert.assertFalse(BashIdentifierUtil.isValidNewVariableName("разработка"));
+    }
+
 }


### PR DESCRIPTION
The result is easy to see in tests file.

Regular expressions are highly optimised and usually run
as fast as manually written code, or faster.
Also, there is less space to make a mistake (as it was
before in these files, with a$a being considered valid).